### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/elpl.el
+++ b/elpl.el
@@ -50,7 +50,9 @@
   :group 'elpl)
 
 (defcustom elpl-use-prompt-regexp t
-  "If non-nil, use `elpl-prompt-regexp' to recognize prompts.")
+  "If non-nil, use `elpl-prompt-regexp' to recognize prompts."
+  :type 'boolean
+  :group 'elpl)
 
 (defvar elpl-cli-file-path
   (concat invocation-directory invocation-name)

--- a/elpl.el
+++ b/elpl.el
@@ -40,6 +40,10 @@
 (defvar elpl-lexical-binding t
   "Whether to use lexical binding when evaluating code.")
 
+(defgroup elpl nil
+  "Emacs Lisp REPL."
+  :group 'lisp)
+
 (defcustom elpl-prompt-read-only t
   "If non-nil, the ELPL prompt is read only."
   :type 'boolean


### PR DESCRIPTION
Hi! Thanks to deverop such a great package!

I found below byte-compile warnings and fix them.

```
Compiling file /Users/conao/dev/repos/melpa/sandbox/elpa/elpl-20190702.1353/elpl.el at Wed Jul  3 0 7:52:10 2019
Entering directory ‘/Users/conao/dev/repos/melpa/sandbox/elpa/elpl-20190702.1353/’
  elpl.el:49:1:Warning: defcustom for ‘elpl-use-prompt-regexp’ fails to specify type
  elpl.el:49:1:Warning: defcustom for ‘elpl-use-prompt-regexp’ fails to specify containing group
  elpl.el:49:1:Warning: defcustom for ‘elpl-use-prompt-regexp’ fails to specify type
  elpl.el:49:1:Warning: defcustom for ‘elpl-use-prompt-regexp’ fails to specify containing group
```